### PR TITLE
Query the species table with hunt unit ObjectID 

### DIFF
--- a/src/js/HuntService.js
+++ b/src/js/HuntService.js
@@ -20,15 +20,6 @@ const getHuntUnitByObjectId = (id) => {
     .catch(console.log);
 };
 
-const getRelatedHuntUnits = (objectIDs) => {
-  const API_URL = `${SPECIES_TABLE_URL}queryRelatedRecords?outFields=*&f=pjson&objectIds=${objectIDs}`;
-  return fetch(API_URL)
-    .then((res) => res.json())
-    .then((data) => data.relatedRecordGroups[0]) // do we need more than one related record here?
-    .then((result) => (result ? result.relatedRecords[0].attributes : []))
-    .catch(console.log);
-};
-
 const getRelatedHuntableSpecies = (objectIDs) => {
   const API_URL = `${HUNT_UNIT_URL}queryRelatedRecords?outFields=*&f=pjson&objectIds=${objectIDs}`;
   return fetch(API_URL)
@@ -89,7 +80,6 @@ const combineSpeciesAndHuntUnit = (huntData) => huntData.species.map((s) => {
 module.exports = {
   getHuntUnitsByOrgCode,
   getHuntUnitByObjectId,
-  getRelatedHuntUnits,
   getRelatedHuntableSpecies,
   getUniqueHuntableSpecies,
   getHuntableSpecies,

--- a/src/js/layers.js
+++ b/src/js/layers.js
@@ -3,7 +3,7 @@ const esri = require('esri-leaflet');
 require('esri-leaflet-renderers');
 
 const emitter = require('./emitter');
-const { getRelatedHuntUnits, getRelatedHuntableSpecies } = require('./HuntService');
+const { getRelatedHuntableSpecies } = require('./HuntService');
 
 const natGeo = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/NatGeo_World_Map/MapServer/tile/{z}/{y}/{x}', {
   attribution: 'Tiles &copy; Esri &mdash; National Geographic, Esri, DeLorme, NAVTEQ, UNEP-WCMC, USGS, NASA, ESA, METI, NRCAN, GEBCO, NOAA, iPC',
@@ -34,17 +34,14 @@ const huntUnits = esri.featureLayer({
   minZoom: 10,
   onEachFeature: (feature, layer) => {
     layer.on('click', (e) => {
+      console.log(e.target.feature.id);
       // Get info on huntable species, append it to info about the hunt unit
-      getRelatedHuntUnits(e.target.feature.id)
-        .then((unit) => {
-          getRelatedHuntableSpecies(unit.OBJECTID).then((species) => {
-            emitter.emit('click:huntunit', {
-              ...feature.properties,
-              huntInfo: unit,
-              species,
-            });
-          });
+      getRelatedHuntableSpecies(e.target.feature.id).then((species) => {
+        emitter.emit('click:huntunit', {
+          ...feature.properties,
+          species,
         });
+      });
     });
     // layer.bindPopup(`<p>${feature.properties.HuntUnit}</p>`);
   },


### PR DESCRIPTION
This addresses #13 

For some reason I was querying the related table twice; the second time included irrelevant OBJECTIDs so it was returning hunts from the wrong refuges.