### PR TITLE
Zipcode

### DIFF
--- a/src/js/Map.js
+++ b/src/js/Map.js
@@ -38,6 +38,10 @@ const Map = function (opts) {
     },
   }).addTo(this.map);
 
+  this.zipcode = L.geoJSON(emptyGeojson, {
+    onEachFeature: (feat, layer) => layer.bindPopup(`<p>${feat.properties.PO_NAME}, ${feat.properties.STATE}</p>`),
+  }).addTo(this.map);
+
   this.filtered = L.geoJSON(emptyGeojson, {
     onEachFeature,
     pointToLayer: (feat, latlng) => L.marker(latlng, { icon: icons.orangeMarker }),
@@ -62,6 +66,11 @@ const Map = function (opts) {
   L.control.zoom({ position: 'topright' }).addTo(this.map);
 
   emitter.on('set:bounds', (bounds) => this.map.fitBounds(bounds));
+
+  emitter.on('found:zipcode', (geojson) => {
+    this.zipcode.clearLayers();
+    this.zipcode.addData(geojson);
+  });
   emitter.on('zoom:refuge', (refuge) => {
     const coordinates = [...refuge.geometry.coordinates].reverse();
     this.map.flyTo(coordinates, 12, { ...paddingOptions });

--- a/src/js/ZipcodeService.js
+++ b/src/js/ZipcodeService.js
@@ -1,8 +1,7 @@
 const API_URL = 'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_ZIP_Code_Points_analysis/FeatureServer/0/';
 
 const getZipCode = (code) => fetch(`${API_URL}query?outFields=PO_NAME%2CSTATE&f=pgeojson&where=ZIP_CODE='${code}'`)
-  .then((res) => res.json())
-  .catch(console.log);
+  .then((res) => res.json());
 
 module.exports = {
   getZipCode,

--- a/src/js/ZipcodeService.js
+++ b/src/js/ZipcodeService.js
@@ -1,0 +1,9 @@
+const API_URL = 'https://services.arcgis.com/P3ePLMYs2RVChkJx/arcgis/rest/services/USA_ZIP_Code_Points_analysis/FeatureServer/0/';
+
+const getZipCode = (code) => fetch(`${API_URL}query?outFields=PO_NAME%2CSTATE&f=pgeojson&where=ZIP_CODE='${code}'`)
+  .then((res) => res.json())
+  .catch(console.log);
+
+module.exports = {
+  getZipCode,
+};


### PR DESCRIPTION
Don't rely on 3MB of local zipcode data. At most we only need a handful of locations, it's silly to download every zipcode centroid in the system.

This should really speed up the zipcode search.