### PR TITLE
Do not display WMAs or WMDs until we have hunt data for them

### DIFF
--- a/src/js/Map.js
+++ b/src/js/Map.js
@@ -50,6 +50,11 @@ const Map = function (opts) {
   this.markers = L.geoJSON(this.data, {
     onEachFeature,
     pointToLayer: (feat, latlng) => L.marker(latlng, { icon: icons.blueMarker }),
+    filter: (feat) => {
+      const type = feat.properties.OrgType;
+      if (type === 'WMD' || type === 'CA') return false;
+      return true;
+    },
   }).addTo(this.map);
 
   layers.natGeo.addTo(this.map);


### PR DESCRIPTION
I'm filtering out WMAs and WMDs; when we have data for these I'll just remove the filter function in the creation of the GeoJSON layer

Addresses #36 