### PR TITLE
Use POST request when dealing with large number of ObjectIDs

### DIFF
--- a/src/js/HuntService.js
+++ b/src/js/HuntService.js
@@ -58,8 +58,12 @@ const getHuntableSpecies = (species) => {
 };
 
 const getHuntUnitFromSpeciesData = (objectIds) => {
-  const API_URL = `${SPECIES_TABLE_URL}queryRelatedRecords?objectIds=${objectIds}&f=pjson&returnGeometry=false&outFields=*`;
-  return fetch(API_URL)
+  const API_URL = `${SPECIES_TABLE_URL}queryRelatedRecords`;
+  return fetch(API_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `objectIds=${objectIds}&outFields=*&returnGeometry=false&f=pjson`,
+  })
     .then((res) => res.json())
     .then((data) => data.relatedRecordGroups)
     .catch(console.log);


### PR DESCRIPTION
When you search for White-tailed deer there are just under 1k hunt units returned. I can't pass 1k objectIds in a URL -- it runs well past the upper limit of a URL length acceptable by browsers and servers. Instead, we need to run a post request as to not encode the objectIds in the request URL.

ESRI doesn't like `'Content-Type': 'application/json'` so I had to encode the result and submit it with `'Content-Type': 'application/x-www-form-urlencoded'`. The application/json request was rejected with a vague CORS error. What a bunch of fun that was to figure out!

I reverse engineered this by using the ESRI REST API query form and selecting the 'POST' button instead of the 'GET' button and inspecting the XHR request. It was encoded as a web form. 