### PR TITLE
Do not show WMDs, CAs, or RAOs from centroid layer

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -21,13 +21,14 @@ const toggleResults = searchPanel.querySelector('.toggle-results');
 
 // Start the app
 const init = () => {
-  const API_URL = 'https://services.arcgis.com/QVENGdaPbd4LUkLV/arcgis/rest/services/FWS_NWRS_HQ_HuntFishStation/FeatureServer/0/query?where=1+%3D+1&outFields=*&f=pgeojson&token=';
+  const API_URL = "https://services.arcgis.com/QVENGdaPbd4LUkLV/arcgis/rest/services/FWS_NWRS_HQ_HuntFishStation/FeatureServer/0/query?where=OrgType%20!%3D%20'WMD'%20AND%20OrgType%20!%3D%20'RAO'%20AND%20OrgType%20!%3D%20'CA'&outFields=*&f=pgeojson&token=";
 
   getUniqueHuntableSpecies().then((res) => helpers.addOptionsToSelect(res, speciesSelect));
 
   fetch(API_URL)
     .then((res) => res.json())
     .then((data) => {
+      console.log(data.features.length);
       const geodata = { ...data, features: data.features.map(helpers.updateFeatureStateName) };
       const states = helpers.flatten(geodata.features
         .map((f) => f.properties.State_Array))


### PR DESCRIPTION
Here's the distinct list of OrgTypes: WMD, CA, RAO, FTC, NFH, NWR, NFHTC, and HNFH

We have hunt unit data for FTC, NFH, NWR, NFHTC, and HNFH

We're now filtering out those that we don't have data for.

Addresses #42 