### PR TITLE
Display hunt unit info in sidebar

### DIFF
--- a/src/js/HuntService.js
+++ b/src/js/HuntService.js
@@ -34,7 +34,7 @@ const getRelatedHuntableSpecies = (objectIDs) => {
   return fetch(API_URL)
     .then((res) => res.json())
     .then((data) => data.relatedRecordGroups[0]) // do we need more than one related record here?
-    .then((result) => result.relatedRecords)
+    .then((result) => ((result && result.relatedRecords) ? result.relatedRecords : []))
     .then((species) => species.map((s) => s.attributes))
     .catch(console.log);
 };
@@ -94,6 +94,17 @@ const combineSpeciesAndHuntUnit = (huntData) => huntData.hunts.map((s) => {
   };
 });
 
+const completeRefugeInfoFromHuntUnit = (unit) => {
+  const getSpecies = getRelatedHuntableSpecies(unit.id);
+  const getFacility = getRefugeInfoByOrgCode(unit.properties.OrgCode);
+
+  return Promise.all([getSpecies, getFacility]).then(([species, facility]) => ({
+    ...unit.properties,
+    species,
+    facility,
+  }));
+};
+
 module.exports = {
   getHuntUnitsByOrgCode,
   getHuntUnitByObjectIds,
@@ -104,4 +115,5 @@ module.exports = {
   combineSpeciesAndHuntUnit,
   getSpecialHunts,
   getRefugeInfoByOrgCode,
+  completeRefugeInfoFromHuntUnit,
 };

--- a/src/js/layers.js
+++ b/src/js/layers.js
@@ -3,7 +3,7 @@ const esri = require('esri-leaflet');
 require('esri-leaflet-renderers');
 
 const emitter = require('./emitter');
-const { getRelatedHuntableSpecies } = require('./HuntService');
+const { completeRefugeInfoFromHuntUnit } = require('./HuntService');
 
 const imagery = L.tileLayer('https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
   attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
@@ -49,11 +49,8 @@ const huntUnits = esri.featureLayer({
     layer.bindTooltip(feature.properties.HuntUnit, { permanent: true });
     layer.on('click', (e) => {
       // Get info on huntable species, append it to info about the hunt unit
-      getRelatedHuntableSpecies(e.target.feature.id).then((species) => {
-        emitter.emit('click:huntunit', {
-          ...feature.properties,
-          species,
-        });
+      completeRefugeInfoFromHuntUnit(feature).then((data) => {
+        emitter.emit('click:huntunit', data);
       });
     });
     // layer.bindPopup(`<p>${feature.properties.HuntUnit}</p>`);

--- a/src/js/search/Results.js
+++ b/src/js/search/Results.js
@@ -26,9 +26,16 @@ const Results = function (opts) {
   this.content.addEventListener('click', this.handleResultClick.bind(this));
   this.toggle.addEventListener('click', this.toggleSearchResults.bind(this));
 
-  emitter.on('click:huntunit', (props) => {
+  const displayHuntUnit = (props) => {
     this.empty();
     this.content.innerHTML = templates.hunt(props);
+    this.loading.setAttribute('aria-hidden', 'true');
+  };
+
+  emitter.on('click:huntunit', displayHuntUnit);
+  emitter.on('zoom:unit', (unit) => {
+    this.loading.setAttribute('aria-hidden', 'false');
+    HuntService.completeRefugeInfoFromHuntUnit(unit).then(displayHuntUnit);
   });
 
   emitter.on('click:refuge', (props) => {

--- a/src/js/templates/hunt.js
+++ b/src/js/templates/hunt.js
@@ -14,12 +14,12 @@ const createListItem = (info) => {
 
 module.exports = (props) => `
   <h2><a href="${props.URL}" target="_blank">${props.OrgName}</a></h2>
-  <p class="hunt-unit-info">Hunt unit: ${props.HuntUnit} (${helpers.formatAcreage(props.Acreage)} acres)</p>
-  <p>${props.DescHunt}</p>
-  ${props.species.length ? '<h3>Huntable species</h3>' : ''}
-  <p class="regulation-details">State regulations for method of take, date/times and bag limit apply unless otherwise noted.</p>
+  <p class="centered"><strong>Hunt unit: ${props.HuntUnit} (${helpers.formatAcreage(props.Acreage)} acres)</strong></p>
+  ${props.Huntable === 'No' ? '<p class="centered"><strong>Hunting is not permitted on this unit</strong></p>' : ''}
+  ${props.facility.DescHunt ? `<p>${props.facility.DescHunt}</p>` : ''}
+  ${props.species && props.species.length ? '<h3>Huntable species</h3>' : ''}
+  ${props.Huntable === 'Yes' ? '<p class="regulation-details">State regulations for method of take, date/times and bag limit apply unless otherwise noted.</p>' : ''}
   ${props.species
-    .map((species) => createListItem({ ...species, url: props.UrlHunting }))
+    .map((species) => createListItem({ ...species, url: props.facility.UrlHunting }))
     .join('')
-}
-`;
+}`;

--- a/src/scss/_search-panel.scss
+++ b/src/scss/_search-panel.scss
@@ -28,13 +28,14 @@
   h2,
   h3,
   .refuge-address,
-  .hunt-unit-info,
+  .hunt-unit-name,
+  .centered,
   .regulation-details {
     text-align: center;
   }
 
   .refuge-address,
-  .hunt-unit-info {
+  .hunt-unit-name {
     font-weight: bold;
   }
 }
@@ -108,7 +109,7 @@
 
 .search-results-content {
   overflow: hidden;
-  margin: 0;
+  margin: 0 0 2rem 0;
   padding: 0;
   transition: all .3s;
 


### PR DESCRIPTION
Addresses #68 

Automatically display information about hunt unit when user clicks on a unit or a zoom-to-unit button